### PR TITLE
refactor sending trnsactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta2",
+    "version": "0.3.20-beta3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.20-beta2",
+            "version": "0.3.20-beta3",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta1",
+    "version": "0.3.20-beta2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.20-beta1",
+            "version": "0.3.20-beta2",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta",
+    "version": "0.3.20-beta1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.20-beta",
+            "version": "0.3.20-beta1",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.10",
+    "version": "0.3.20-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.10",
+            "version": "0.3.20-beta",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.6-Beta36",
+    "version": "0.3.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.6-Beta36",
+            "version": "0.3.10",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta3",
+    "version": "0.3.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@neoswap/solana",
-            "version": "0.3.20-beta3",
+            "version": "0.3.21",
             "license": "MIT",
             "dependencies": {
                 "@coral-xyz/anchor": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.10",
+    "version": "0.3.20-beta",
     "repository": {
         "type": "git",
         "url": "git+htt// Data after initializing the swapps://github.com/neoswap-ai/neo-swap-npm.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta3",
+    "version": "0.3.21",
     "repository": {
         "type": "git",
         "url": "git+htt// Data after initializing the swapps://github.com/neoswap-ai/neo-swap-npm.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta",
+    "version": "0.3.20-beta1",
     "repository": {
         "type": "git",
         "url": "git+htt// Data after initializing the swapps://github.com/neoswap-ai/neo-swap-npm.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta1",
+    "version": "0.3.20-beta2",
     "repository": {
         "type": "git",
         "url": "git+htt// Data after initializing the swapps://github.com/neoswap-ai/neo-swap-npm.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@neoswap/solana",
-    "version": "0.3.20-beta2",
+    "version": "0.3.20-beta3",
     "repository": {
         "type": "git",
         "url": "git+htt// Data after initializing the swapps://github.com/neoswap-ai/neo-swap-npm.git"

--- a/src/processor/cancelAndCloseSwap.ts
+++ b/src/processor/cancelAndCloseSwap.ts
@@ -1,5 +1,5 @@
 import { Cluster, Keypair, PublicKey } from "@solana/web3.js";
-import { sendBundledTransactions } from "../utils/sendBundledTransactions.function";
+import { sendBundledTransactionsV2 } from "../utils/sendBundledTransactions.function";
 import { TxWithSigner } from "../utils/types";
 import { createCancelSwapInstructions } from "../programInstructions/cancelSwap.instructions";
 import { createValidateCanceledInstructions } from "../programInstructions/subFunction/validateCanceled.instructions";
@@ -13,6 +13,7 @@ export async function cancelAndCloseSwap(Data: {
     simulation?: boolean;
     skipConfirmation?: boolean;
     skipFinalize?: boolean;
+    prioritizationFee?: number;
 }): Promise<string[]> {
     let txToSend: TxWithSigner[] = [];
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
@@ -37,13 +38,14 @@ export async function cancelAndCloseSwap(Data: {
 
     if (validateCancelTxData) txToSend.push(...validateCancelTxData);
 
-    const transactionHashs = await sendBundledTransactions({
+    const transactionHashs = await sendBundledTransactionsV2({
         provider: program.provider as AnchorProvider,
         txsWithoutSigners: txToSend,
         signer: Data.signer,
         clusterOrUrl: Data.clusterOrUrl,
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
+        prioritizationFee: Data.prioritizationFee,
     });
 
     return transactionHashs;

--- a/src/processor/cancelAndCloseSwap.ts
+++ b/src/processor/cancelAndCloseSwap.ts
@@ -14,6 +14,7 @@ export async function cancelAndCloseSwap(Data: {
     skipConfirmation?: boolean;
     skipFinalize?: boolean;
     prioritizationFee?: number;
+    retryDelay?: number;
 }): Promise<string[]> {
     let txToSend: TxWithSigner[] = [];
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
@@ -46,6 +47,7 @@ export async function cancelAndCloseSwap(Data: {
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
         prioritizationFee: Data.prioritizationFee,
+        retryDelay: Data.retryDelay
     });
 
     return transactionHashs;

--- a/src/processor/claimAndCloseSwap.ts
+++ b/src/processor/claimAndCloseSwap.ts
@@ -1,5 +1,5 @@
 import { Cluster, Keypair, PublicKey } from "@solana/web3.js";
-import { sendBundledTransactions } from "../utils/sendBundledTransactions.function";
+import { sendBundledTransactionsV2 } from "../utils/sendBundledTransactions.function";
 import { TxWithSigner } from "../utils/types";
 import { createClaimSwapInstructions } from "../programInstructions/claimSwap.instructions";
 import { validateDeposit } from "../programInstructions/subFunction/validateDeposit.instructions";
@@ -14,6 +14,7 @@ export async function claimAndCloseSwap(Data: {
     skipFinalize?: boolean;
     simulation?: boolean;
     skipConfirmation?: boolean;
+    prioritizationFee?: number;
 }): Promise<string[]> {
     let txToSend: TxWithSigner[] = [];
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
@@ -48,13 +49,14 @@ export async function claimAndCloseSwap(Data: {
         if (validateClaimTxData) txToSend.push(...validateClaimTxData);
     }
 
-    const transactionHashs = await sendBundledTransactions({
+    const transactionHashs = await sendBundledTransactionsV2({
         provider: program.provider as AnchorProvider,
         txsWithoutSigners: txToSend,
         signer: Data.signer,
         clusterOrUrl: Data.clusterOrUrl,
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
+        prioritizationFee: Data.prioritizationFee,
     });
 
     return transactionHashs;

--- a/src/processor/claimAndCloseSwap.ts
+++ b/src/processor/claimAndCloseSwap.ts
@@ -17,8 +17,16 @@ export async function claimAndCloseSwap(Data: {
     prioritizationFee?: number;
     retryDelay?: number;
 }): Promise<string[]> {
-    let txToSend: TxWithSigner[] = [];
-    const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
+    const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });    
+    let sendConfig = {
+        provider: program.provider as AnchorProvider,
+        signer: Data.signer,
+        clusterOrUrl: Data.clusterOrUrl,
+        simulation: Data.simulation,
+        skipConfirmation: Data.skipConfirmation,
+        prioritizationFee: Data.prioritizationFee,
+        retryDelay: Data.retryDelay,
+    };
 
     let validateDepositTxData = await validateDeposit({
         swapDataAccount: Data.swapDataAccount,
@@ -26,7 +34,6 @@ export async function claimAndCloseSwap(Data: {
         clusterOrUrl: Data.clusterOrUrl,
         program,
     });
-    if (validateDepositTxData) txToSend.push(...validateDepositTxData);
 
     // if (!Data.skipFinalize) Data.skipFinalize = false;
     let claimTxData = await createClaimSwapInstructions({
@@ -37,29 +44,51 @@ export async function claimAndCloseSwap(Data: {
         program,
     });
 
-    if (claimTxData) txToSend.push(...claimTxData);
-
+    let validateClaimTxData;
     if (!Data.skipFinalize) {
-        let validateClaimTxData = await createValidateClaimedInstructions({
+        validateClaimTxData = await createValidateClaimedInstructions({
             swapDataAccount: Data.swapDataAccount,
             signer: Data.signer.publicKey,
             clusterOrUrl: Data.clusterOrUrl,
             program,
             // SkipFinalize: Data.skipFinalize,
         });
-        if (validateClaimTxData) txToSend.push(...validateClaimTxData);
     }
 
-    const transactionHashs = await sendBundledTransactionsV2({
-        provider: program.provider as AnchorProvider,
-        txsWithoutSigners: txToSend,
-        signer: Data.signer,
-        clusterOrUrl: Data.clusterOrUrl,
-        simulation: Data.simulation,
-        skipConfirmation: Data.skipConfirmation,
-        prioritizationFee: Data.prioritizationFee,
-        retryDelay: Data.retryDelay
-    });
+    let transactionHashs: string[] = [];
+
+    if (validateDepositTxData) {
+        await sendBundledTransactionsV2({
+            txsWithoutSigners: validateDepositTxData,
+            ...sendConfig,
+        }).then((txhs) => {
+            transactionHashs.push(...txhs);
+        }).catch((error) => {
+            console.log("error", error);
+        });
+    }
+
+    if (claimTxData) {
+        await sendBundledTransactionsV2({
+            txsWithoutSigners: claimTxData,
+            ...sendConfig,
+        }).then((txhs) => {
+            transactionHashs.push(...txhs);
+        }).catch((error) => {
+            console.log("error", error);
+        });
+    }
+
+    if (validateClaimTxData) {
+        await sendBundledTransactionsV2({
+            txsWithoutSigners: validateClaimTxData,
+            ...sendConfig,
+        }).then((txhs) => {
+            transactionHashs.push(...txhs);
+        }).catch((error) => {
+            console.log("error", error);
+        });
+    }
 
     return transactionHashs;
 }

--- a/src/processor/claimAndCloseSwap.ts
+++ b/src/processor/claimAndCloseSwap.ts
@@ -15,6 +15,7 @@ export async function claimAndCloseSwap(Data: {
     simulation?: boolean;
     skipConfirmation?: boolean;
     prioritizationFee?: number;
+    retryDelay?: number;
 }): Promise<string[]> {
     let txToSend: TxWithSigner[] = [];
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
@@ -57,6 +58,7 @@ export async function claimAndCloseSwap(Data: {
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
         prioritizationFee: Data.prioritizationFee,
+        retryDelay: Data.retryDelay
     });
 
     return transactionHashs;

--- a/src/processor/depositSwap.ts
+++ b/src/processor/depositSwap.ts
@@ -14,6 +14,16 @@ export async function depositSwap(Data: {
     retryDelay?: number;
 }): Promise<string[]> {
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
+    let sendConfig = {
+        provider: program.provider as AnchorProvider,
+        signer: Data.signer,
+        clusterOrUrl: Data.clusterOrUrl,
+        simulation: Data.simulation,
+        skipConfirmation: Data.skipConfirmation,
+        prioritizationFee: Data.prioritizationFee,
+        retryDelay: Data.retryDelay,
+    };
+
     let depositSwapData = await createDepositSwapInstructions({
         swapDataAccount: Data.swapDataAccount,
         user: Data.signer.publicKey,
@@ -22,14 +32,8 @@ export async function depositSwap(Data: {
     });
 
     const transactionHashs = await sendBundledTransactionsV2({
-        provider: program.provider as AnchorProvider,
         txsWithoutSigners: depositSwapData,
-        signer: Data.signer,
-        clusterOrUrl: Data.clusterOrUrl,
-        simulation: Data.simulation,
-        skipConfirmation: Data.skipConfirmation,
-        prioritizationFee: Data.prioritizationFee,
-        retryDelay: Data.retryDelay,
+        ...sendConfig,
     });
 
     return transactionHashs;

--- a/src/processor/depositSwap.ts
+++ b/src/processor/depositSwap.ts
@@ -1,5 +1,5 @@
 import { Cluster, Keypair, PublicKey } from "@solana/web3.js";
-import { sendBundledTransactions } from "../utils/sendBundledTransactions.function";
+import { sendBundledTransactionsV2 } from "../utils/sendBundledTransactions.function";
 import { createDepositSwapInstructions } from "../programInstructions/depositSwap.instructions";
 import { getProgram } from "../utils/getProgram.obj";
 import { AnchorProvider } from "@coral-xyz/anchor";
@@ -10,6 +10,7 @@ export async function depositSwap(Data: {
     clusterOrUrl: Cluster | string;
     simulation?: boolean;
     skipConfirmation?: boolean;
+    prioritizationFee?: number;
 }): Promise<string[]> {
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
     let depositSwapData = await createDepositSwapInstructions({
@@ -19,13 +20,14 @@ export async function depositSwap(Data: {
         program,
     });
 
-    const transactionHashs = await sendBundledTransactions({
+    const transactionHashs = await sendBundledTransactionsV2({
         provider: program.provider as AnchorProvider,
         txsWithoutSigners: depositSwapData,
         signer: Data.signer,
         clusterOrUrl: Data.clusterOrUrl,
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
+        prioritizationFee: Data.prioritizationFee,
     });
 
     return transactionHashs;

--- a/src/processor/depositSwap.ts
+++ b/src/processor/depositSwap.ts
@@ -11,6 +11,7 @@ export async function depositSwap(Data: {
     simulation?: boolean;
     skipConfirmation?: boolean;
     prioritizationFee?: number;
+    retryDelay?: number;
 }): Promise<string[]> {
     const program = getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer });
     let depositSwapData = await createDepositSwapInstructions({
@@ -28,6 +29,7 @@ export async function depositSwap(Data: {
         simulation: Data.simulation,
         skipConfirmation: Data.skipConfirmation,
         prioritizationFee: Data.prioritizationFee,
+        retryDelay: Data.retryDelay,
     });
 
     return transactionHashs;

--- a/src/processor/initializeSwap.ts
+++ b/src/processor/initializeSwap.ts
@@ -14,6 +14,7 @@ export async function initializeSwap(Data: {
     validateOwnership?: "warning" | "error";
     validateOwnershipIgnore?: string[];
     prioritizationFee?: number;
+    retryDelay?: number;
 }): Promise<{
     initializeData: InitializeData;
     transactionHashs: string[];
@@ -41,7 +42,8 @@ export async function initializeSwap(Data: {
             clusterOrUrl: Data.clusterOrUrl,
             simulation: Data.simulation,
             skipConfirmation: Data.skipConfirmation,
-            prioritizationFee: Data.prioritizationFee
+            prioritizationFee: Data.prioritizationFee,
+            retryDelay: Data.retryDelay
         });
 
         return {

--- a/src/processor/initializeSwap.ts
+++ b/src/processor/initializeSwap.ts
@@ -1,6 +1,6 @@
 import { Cluster, Keypair, PublicKey } from "@solana/web3.js";
 import { createInitializeSwapInstructions } from "../programInstructions/initializeSwap.instructions";
-import { sendBundledTransactions } from "../utils/sendBundledTransactions.function";
+import { sendBundledTransactionsV2 } from "../utils/sendBundledTransactions.function";
 import { InitializeData, SwapInfo } from "../utils/types";
 import { getProgram } from "../utils/getProgram.obj";
 import { AnchorProvider } from "@coral-xyz/anchor";
@@ -34,7 +34,7 @@ export async function initializeSwap(Data: {
     //     throw initializeData.warning;
     // }
     try {
-        const transactionHashs = await sendBundledTransactions({
+        const transactionHashs = await sendBundledTransactionsV2({
             provider: program.provider as AnchorProvider,
             txsWithoutSigners: initializeData.txWithoutSigner,
             signer: Data.signer,

--- a/src/processor/initializeSwap.ts
+++ b/src/processor/initializeSwap.ts
@@ -13,6 +13,7 @@ export async function initializeSwap(Data: {
     skipConfirmation?: boolean;
     validateOwnership?: "warning" | "error";
     validateOwnershipIgnore?: string[];
+    prioritizationFee?: number;
 }): Promise<{
     initializeData: InitializeData;
     transactionHashs: string[];
@@ -40,6 +41,7 @@ export async function initializeSwap(Data: {
             clusterOrUrl: Data.clusterOrUrl,
             simulation: Data.simulation,
             skipConfirmation: Data.skipConfirmation,
+            prioritizationFee: Data.prioritizationFee
         });
 
         return {

--- a/src/programInstructions/initializeSwap.instructions.ts
+++ b/src/programInstructions/initializeSwap.instructions.ts
@@ -14,6 +14,7 @@ import {
     SwapIdentity,
     SwapInfo,
     TxWithSigner,
+    InitTxs
 } from "../utils/types";
 import { Program } from "@coral-xyz/anchor";
 import { findOrCreateAta } from "../utils/findOrCreateAta.function";
@@ -65,36 +66,45 @@ InitializeData> {
         });
 
         let txWithoutSigner: TxWithSigner[] = [];
+        let initTxs: InitTxs = {};
 
         if (initInstruction) {
-            txWithoutSigner.push({
+            let tx = {
                 tx: new Transaction().add(initInstruction),
                 // signers: [signer],
-            });
+            }
+            txWithoutSigner.push(tx);
+            initTxs.init = [tx];
         } else {
             console.log("Init-Initialize swap skipped");
         }
 
         if (addInstructions.ix) {
+            initTxs.add = [];
             addInstructions.ix.map((addInstruction) => {
-                txWithoutSigner.push({
+                let tx = {
                     tx: new Transaction().add(...addInstruction),
                     // signers: [signer],
-                });
+                }
+                txWithoutSigner.push(tx);
+                initTxs.add?.push(tx);
             });
         } else {
             console.log("Add-Instrutions was skipped");
         }
 
-        txWithoutSigner.push({
+        let validateTx = {
             tx: new Transaction().add(validateInstruction),
-        });
+        };
+        txWithoutSigner.push(validateTx);
+        initTxs.validate = [validateTx];
 
         return {
             // initializeData: {
             swapIdentity,
             programId: program.programId,
             txWithoutSigner,
+            initTxs,
             warning: addInstructions.warning,
             // },
             // shouldError: addInstructions.shouldError,

--- a/src/programInstructions/subFunction/claim.nft.instructions.ts
+++ b/src/programInstructions/subFunction/claim.nft.instructions.ts
@@ -36,15 +36,13 @@ export async function getClaimNftInstructions(Data: {
 }> {
     let instruction = [];
     let newAtas = [];
-    const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
+    
+    instruction.push(ComputeBudgetProgram.setComputeUnitLimit({
         units: 600000,
-    });
-
-    const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({
-        microLamports: 1,
-    });
-    instruction.push(modifyComputeUnits);
-    instruction.push(addPriorityFee);
+    }));
+    // instruction.push(ComputeBudgetProgram.setComputeUnitPrice({
+    //     microLamports: 1,
+    // }));
     const { mintAta: destinaryMintAta, instruction: destinaryMintAtaTx } = await findOrCreateAta({
         connection: Data.program.provider.connection,
         owner: Data.destinary,

--- a/src/utils/addPrioritizationFee.ts
+++ b/src/utils/addPrioritizationFee.ts
@@ -1,0 +1,10 @@
+import { TxWithSigner } from "./types";
+import { ComputeBudgetProgram } from "@solana/web3.js";
+
+export function addPrioritizationFee(tx: TxWithSigner, fee?: number) {
+    if (fee) {
+        tx.tx = tx.tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: fee }));
+    }
+
+    return tx;
+}

--- a/src/utils/sendBundledTransactions.function.ts
+++ b/src/utils/sendBundledTransactions.function.ts
@@ -1,4 +1,4 @@
-import { Cluster, Connection, Keypair, VersionedTransaction } from "@solana/web3.js";
+import { Cluster, Connection, Keypair, VersionedTransaction, Finality } from "@solana/web3.js";
 import { getProgram } from "./getProgram.obj";
 import { ErrorFeedback, TxWithSigner } from "./types";
 import { isConfirmedTx } from "./isConfirmedTx.function";
@@ -47,22 +47,22 @@ export async function sendBundledTransactions(Data: {
         if (!provider.sendAll) throw { message: "your provider is not an AnchorProvider type" };
         if (!Data.simulation) Data.simulation = false;
 
-        const transactionHashs = await Promise.all(
-            Data.txsWithoutSigners.map(async (txWithoutSigner, d) => {
-                txWithoutSigner.tx.sign(Data.signer);
-                await delay(250 * d);
-                return await provider.connection.sendTransaction(
-                    txWithoutSigner.tx,
-                    [Data.signer],
-                    {
-                        skipPreflight: Data.simulation,
-                    }
-                );
-            })
-        );
+        // const transactionHashs = await Promise.all(
+        //     Data.txsWithoutSigners.map(async (txWithoutSigner, d) => {
+        //         txWithoutSigner.tx.sign(Data.signer);
+        //         await delay(250 * d);
+        //         return await provider.connection.sendTransaction(
+        //             txWithoutSigner.tx,
+        //             [Data.signer],
+        //             {
+        //                 skipPreflight: Data.simulation,
+        //             }
+        //         );
+        //     })
+        // );
 
-        provider.sendAll(txsWithSigners, {
-            maxRetries: 5,
+        const transactionHashs = await provider.sendAll(txsWithSigners, {
+            maxRetries: 10,
             skipPreflight: !Data.simulation,
             commitment: "single",
             // preflightCommitment:"singleGossip"
@@ -92,4 +92,137 @@ export async function sendBundledTransactions(Data: {
     } catch (error) {
         throw error;
     }
+}
+
+export async function sendBundledTransactionsV2(Data: {
+    txsWithoutSigners: TxWithSigner[];
+    signer: Keypair;
+    clusterOrUrl: Cluster | string;
+    simulation?: boolean;
+    skipConfirmation?: boolean;
+    provider?: AnchorProvider;
+    prioritizationFee?: number;
+}): Promise<string[]> {
+    try {
+        // console.log(txWithSigners);
+
+        if (Data.prioritizationFee) {
+            Data.txsWithoutSigners = Data.txsWithoutSigners.map((tx) =>
+                addPrioritizationFee(tx, Data.prioritizationFee)
+            );
+        }
+
+        const provider = Data.provider
+            ? Data.provider
+            : getProgram({ clusterOrUrl: Data.clusterOrUrl, signer: Data.signer }).provider;
+
+        const txsWithSigners = Data.txsWithoutSigners.map((txWithSigners) => {
+            txWithSigners.signers = [Data.signer];
+            txWithSigners.tx.feePayer = Data.signer.publicKey;
+            return txWithSigners;
+        });
+        // console.log('program',program);
+
+        console.log(
+            "User ",
+            Data.signer.publicKey.toBase58(),
+            " has found to have ",
+            txsWithSigners.length,
+            " transaction(s) to send \nBroadcasting to blockchain ..."
+        );
+        if (!Data.simulation) Data.simulation = false;
+
+        let transactionHashs = [];
+
+        for (let i = 0; i < txsWithSigners.length; i++) {
+            let hash = await sendTransaction(
+                txsWithSigners[i],
+                provider.connection,
+                !Data.simulation,
+                "confirmed"
+            );
+            transactionHashs.push(hash);
+        }
+        return transactionHashs;
+    } catch (error) {
+        throw error;
+    }
+}
+
+async function sendTransaction(
+    tx: TxWithSigner,
+    connection: Connection,
+    skipPreflight: boolean,
+    commitment: Finality
+): Promise<string> {
+    if (!tx.signers) {
+        throw new Error("No signers provided");
+    }
+
+    let recentBlockhash = await connection.getLatestBlockhash("confirmed");
+    tx.tx.recentBlockhash = recentBlockhash.blockhash;
+
+    let vtx = new VersionedTransaction(tx.tx.compileMessage());
+    vtx.sign(tx.signers);
+
+    let hash = await connection.sendTransaction(vtx, {
+        skipPreflight,
+    });
+
+    let keepChecking = true;
+    while (keepChecking) {
+        let check = await checkTransaction({
+            connection,
+            txHash: hash,
+            blockheight: recentBlockhash.lastValidBlockHeight,
+            commitment,
+            tx: vtx,
+        });
+        
+        if (check === true) {
+            keepChecking = false;
+        } else if (check === null) {
+            await delay(5000);
+        } else {
+            throw new Error("Transaction failed");
+        }
+    }
+
+    return hash;
+}
+
+async function checkTransaction(Data: {
+    connection: Connection;
+    txHash: string;
+    blockheight: number;
+    commitment: Finality;
+    tx?: VersionedTransaction;
+}): Promise<boolean | null> {
+    let { connection, txHash, blockheight, commitment, tx } = Data;
+
+    let status = await connection.getTransaction(txHash, {
+        commitment,
+        maxSupportedTransactionVersion: 0,
+    });
+
+    if (status === null) {
+        let block = await connection.getLatestBlockhash(commitment);
+
+        if (blockheight + 151 < block.lastValidBlockHeight) {
+            throw new Error("Could not find transaction after 151 blocks.");
+        }
+
+        if (tx) {
+            await connection.sendTransaction(tx, {
+                skipPreflight: true,
+            });
+        }
+        return null;
+    }
+
+    if (status.meta?.err) {
+        throw new Error("Transaction failed: " + JSON.stringify(status.meta.err));
+    }
+
+    return true;
 }

--- a/src/utils/sendBundledTransactions.function.ts
+++ b/src/utils/sendBundledTransactions.function.ts
@@ -4,6 +4,7 @@ import { ErrorFeedback, TxWithSigner } from "./types";
 import { isConfirmedTx } from "./isConfirmedTx.function";
 import { AnchorProvider } from "@coral-xyz/anchor";
 import { delay } from "./delay";
+import { addPrioritizationFee } from "./addPrioritizationFee";
 
 // const getProgram  from "./getProgram.obj");
 
@@ -14,9 +15,16 @@ export async function sendBundledTransactions(Data: {
     simulation?: boolean;
     skipConfirmation?: boolean;
     provider?: AnchorProvider;
+    prioritizationFee?: number;
 }): Promise<string[]> {
     try {
         // console.log(txWithSigners);
+
+        if (Data.prioritizationFee) {
+            Data.txsWithoutSigners = Data.txsWithoutSigners.map((tx) =>
+                addPrioritizationFee(tx, Data.prioritizationFee)
+            );
+        }
 
         const provider = Data.provider
             ? Data.provider

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -262,5 +262,12 @@ export type InitializeData = {
     swapIdentity: SwapIdentity;
     programId: PublicKey;
     txWithoutSigner: TxWithSigner[];
+    initTxs?: InitTxs;
     warning: string;
+};
+
+export type InitTxs = {
+    init?: TxWithSigner[];
+    add?: TxWithSigner[];
+    validate?: TxWithSigner[];
 };


### PR DESCRIPTION
- Update package-lock.json and add prioritization fee functionality
- Update sendBundledTransactions function to include new parameters and improve transaction handling
- Update sendBundledTransactions function to sendBundledTransactionsV2
- 0.3.20-beta
- 0.3.20-beta1
- Add retryDelay parameter to cancelAndCloseSwap, claimAndCloseSwap, depositSwap, and initializeSwap functions
- 0.3.20-beta2
- Update compute unit limit in claim NFT instructions
- 0.3.20-beta3
- Add InitTxs type and update transaction handling
